### PR TITLE
Ensure str is declared when ref'd in condition

### DIFF
--- a/grammar/errors.go
+++ b/grammar/errors.go
@@ -3,6 +3,7 @@ package grammar
 import "fmt"
 
 func recoverParse(err *error) {
+	currentRule = nil
 	if r := recover(); r != nil {
 		e := fmt.Errorf("%s", r)
 		*err = e

--- a/grammar/grammar.y
+++ b/grammar/grammar.y
@@ -7,7 +7,10 @@ import (
     "github.com/CapacitorSet/yara-parser/data"
 )
 
-var ParsedRuleset data.RuleSet
+var (
+    ParsedRuleset data.RuleSet
+    currentRule   *data.Rule
+)
 
 type regexPair struct {
     text string
@@ -198,11 +201,16 @@ rule
               }
               idx[s.ID] = struct{}{}
           }
+
+          // So we can refer to this rule while parsing condition.
+          // Ptr changes in every action, so be careful...
+          currentRule = &$<yr>4
       }
       condition _RBRACE_
       {
           $<yr>4.Condition = $<expr>10
           $$ = $<yr>4
+          currentRule = nil // Done with this rule
       }
     ;
 
@@ -452,6 +460,17 @@ expression
       }
     | _STRING_IDENTIFIER_
       {
+        var declared bool
+        for _, s := range currentRule.Strings {
+            if s.ID == $1 {
+                declared = true
+                break
+            }
+        }
+        if !declared {
+            err := fmt.Errorf(`Undefined string identifier "%s"`, $1)
+            panic(err)
+        }
         $$ = data.Expression{Left: data.TemporaryString{Identifier: $1}}
       }
     | _STRING_IDENTIFIER_ _AT_ primary_expression


### PR DESCRIPTION
I hit "edit" on your file to propose this change.  Not sure if I'm making a mess when it comes to the PR chain.  Obviously this is in regards to https://github.com/Northern-Lights/yara-parser/pull/10

When a _STRING_IDENTIFIER_ is parsed, we can determine whether it was previously declared.  I would like to use this to allow us to get a reference to a `*data.String` from any of `#identifier`, `@identifier`, or `$identifier` in the condition.  What do you think of holding a pointer to the current rule being parsed so that we can access its strings, meta, etc.?